### PR TITLE
Implement yield cleanup and processing events

### DIFF
--- a/src/CollectionsVault.sol
+++ b/src/CollectionsVault.sol
@@ -746,4 +746,21 @@ contract CollectionsVault is ERC4626, ICollectionsVault, AccessControl, Reentran
             collection.totalAssetsDeposited
         );
     }
+
+    /// @notice Resets the flags tracking whether collection yield was applied
+    /// for a given epoch. Useful when starting a new epoch to clean up storage.
+    /// @param epochId The epoch id to reset flags for.
+    /// @param collectionsToReset The list of collection addresses to reset.
+    function resetEpochCollectionYieldFlags(uint256 epochId, address[] calldata collectionsToReset)
+        external
+        onlyRole(ADMIN_ROLE)
+    {
+        uint256 length = collectionsToReset.length;
+        for (uint256 i = 0; i < length;) {
+            delete epochCollectionYieldApplied[epochId][collectionsToReset[i]];
+            unchecked {
+                ++i;
+            }
+        }
+    }
 }

--- a/src/EpochManager.sol
+++ b/src/EpochManager.sol
@@ -35,11 +35,23 @@ contract EpochManager is Ownable, AccessControl, ReentrancyGuard {
     event EpochProcessingStarted(uint256 indexed epochId);
 
     /**
+     * @dev Emitted when processing of an epoch has started. Alias of
+     * `EpochProcessingStarted` for easier integrations.
+     */
+    event ProcessingStarted(uint256 indexed epochId);
+
+    /**
      * @dev Emitted when an epoch is marked as failed.
      * @param epochId The ID of the epoch.
      * @param reason The reason for the failure.
      */
     event EpochFailed(uint256 indexed epochId, string reason);
+
+    /**
+     * @dev Emitted when processing of an epoch fails and it is forcefully
+     * aborted. Mirrors `EpochFailed` but uses a distinct event name.
+     */
+    event ProcessingFailed(uint256 indexed epochId, string reason);
 
     /**
      * @dev Emitted when yield is allocated to a vault for a specific epoch.
@@ -222,6 +234,7 @@ contract EpochManager is Ownable, AccessControl, ReentrancyGuard {
 
         epoch.status = EpochStatus.Processing;
         emit EpochProcessingStarted(epochId);
+        emit ProcessingStarted(epochId);
     }
 
     /**
@@ -400,6 +413,7 @@ contract EpochManager is Ownable, AccessControl, ReentrancyGuard {
 
         epoch.status = EpochStatus.Failed;
         emit EpochFailed(epochId, reason);
+        emit ProcessingFailed(epochId, reason);
     }
 
     function grantVaultRole(address vault) external onlyOwner {

--- a/src/interfaces/ICollectionsVault.sol
+++ b/src/interfaces/ICollectionsVault.sol
@@ -139,5 +139,6 @@ interface ICollectionsVault is IERC4626 {
     function allocateEpochYield(uint256 amount) external;
     function allocateYieldToEpoch(uint256 epochId) external;
     function applyCollectionYieldForEpoch(address collection, uint256 epochId) external;
+    function resetEpochCollectionYieldFlags(uint256 epochId, address[] calldata collections) external;
     function getEpochYieldAllocated(uint256 epochId) external view returns (uint256 amount);
 }


### PR DESCRIPTION
## Summary
- emit `ProcessingStarted` and `ProcessingFailed` events from `EpochManager`
- add admin helper to reset `epochCollectionYieldApplied` flags

## Testing
- `forge build --skip test`

------
https://chatgpt.com/codex/tasks/task_e_684afd4ec2f88320ba9016a766261adc