### PR TITLE
Implement cumulative Merkle tree claims

### DIFF
--- a/src/interfaces/IDebtSubsidizer.sol
+++ b/src/interfaces/IDebtSubsidizer.sol
@@ -7,8 +7,7 @@ import {ICollectionRegistry} from "./ICollectionRegistry.sol";
 interface IDebtSubsidizer {
     struct ClaimData {
         address recipient; // recipient of the subsidy
-        address collection; // collection address for which subsidy is claimed
-        uint256 amount; // amount to claim, as per Merkle leaf
+        uint256 totalEarned; // cumulative amount earned as encoded in the leaf
         bytes32[] merkleProof; // Merkle proof for the claim
     }
 
@@ -20,9 +19,7 @@ interface IDebtSubsidizer {
     event NewCollectionWhitelisted(address indexed vaultAddress, address indexed collectionAddress);
     event WhitelistCollectionRemoved(address indexed vaultAddress, address indexed collectionAddress);
     event TrustedSignerUpdated(address oldSigner, address newSigner, address indexed changedBy);
-    event SubsidyClaimed(
-        address indexed vaultAddress, address indexed recipient, address indexed collection, uint256 amount
-    );
+    event SubsidyClaimed(address indexed vaultAddress, address indexed recipient, uint256 amount);
     event MerkleRootUpdated(address indexed vaultAddress, bytes32 merkleRoot, address indexed updatedBy);
     event VaultAdded(
         address indexed vaultAddress, address indexed cTokenAddress, address indexed lendingManagerAddress
@@ -62,7 +59,6 @@ interface IDebtSubsidizer {
     error InvalidMerkleProof();
     error MerkleRootNotSet();
     error AlreadyClaimed();
-    error LeafAlreadyClaimed();
 
     // --- Vault Management ---
     function addVault(address vaultAddress_, address lendingManagerAddress_) external;


### PR DESCRIPTION
## Summary
- switch DebtSubsidizer to cumulative Merkle tree leaves (`account,totalEarned`)
- remove per-leaf tracking and store claimed totals per user
- update events and interface for new claim data

## Testing
- `forge soldeer install`
- `forge build src`

------
https://chatgpt.com/codex/tasks/task_e_685044e33c108320a9c5620c48e3e934