### PR TITLE
Adjust vault asset accounting

### DIFF
--- a/src/interfaces/ICollectionsVault.sol
+++ b/src/interfaces/ICollectionsVault.sol
@@ -110,6 +110,7 @@ interface ICollectionsVault is IERC4626 {
 
     function collectionTotalAssetsDeposited(address collectionAddress) external view returns (uint256);
     function totalAssetsDepositedAllCollections() external view returns (uint256);
+    function totalYieldReserved() external view returns (uint256);
     function setLendingManager(address _lendingManagerAddress) external;
     function setDebtSubsidizer(address _debtSubsidizerAddress) external;
 


### PR DESCRIPTION
## Summary
- track yield reserved for subsidies
- prevent collections from withdrawing reserved yield
- exclude reserved yield from ERC4626 totalAssets reporting
- decrement reserves when subsidies are paid

## Testing
- `forge build src`
- `forge test` *(no tests present)*

------
https://chatgpt.com/codex/tasks/task_e_6850734b51ac8320b7b418a0272cd54b