### PR TITLE
Unify role constants

### DIFF
--- a/src/CollectionRegistry.sol
+++ b/src/CollectionRegistry.sol
@@ -4,9 +4,10 @@ pragma solidity ^0.8.20;
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {ICollectionsVault} from "./interfaces/ICollectionsVault.sol";
 import {ICollectionRegistry} from "./interfaces/ICollectionRegistry.sol";
+import {Roles} from "./Roles.sol";
 
 contract CollectionRegistry is ICollectionRegistry, AccessControl {
-    bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
+    bytes32 public constant MANAGER_ROLE = Roles.MANAGER_ROLE;
 
     mapping(address => ICollectionRegistry.Collection) private _collections;
     address[] private _allCollections;

--- a/src/CollectionsVault.sol
+++ b/src/CollectionsVault.sol
@@ -6,6 +6,7 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Roles} from "./Roles.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
@@ -25,8 +26,8 @@ contract CollectionsVault is ERC4626, ICollectionsVault, AccessControl, Reentran
     using SafeERC20 for IERC20;
     using Math for uint256;
 
-    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
-    bytes32 public constant DEBT_SUBSIDIZER_ROLE = keccak256("DEBT_SUBSIDIZER_ROLE");
+    bytes32 public constant ADMIN_ROLE = Roles.ADMIN_ROLE;
+    bytes32 public constant DEBT_SUBSIDIZER_ROLE = Roles.DEBT_SUBSIDIZER_ROLE;
 
     ILendingManager public lendingManager;
     IEpochManager public epochManager;

--- a/src/EpochManager.sol
+++ b/src/EpochManager.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Roles} from "./Roles.sol";
 
 /**
  * @title EpochManager
@@ -73,7 +74,7 @@ contract EpochManager is Ownable, AccessControl, ReentrancyGuard {
      */
     event AutomatedSystemUpdated(address indexed newAutomatedSystem);
 
-    bytes32 public constant VAULT_ROLE = keccak256("VAULT_ROLE");
+    bytes32 public constant VAULT_ROLE = Roles.VAULT_ROLE;
 
     enum EpochStatus {
         Pending, // Epoch has not started yet

--- a/src/LendingManager.sol
+++ b/src/LendingManager.sol
@@ -7,6 +7,7 @@ import {AccessControlEnumerable} from "@openzeppelin/contracts/access/extensions
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {Roles} from "./Roles.sol";
 
 import {ILendingManager} from "./interfaces/ILendingManager.sol";
 import {CErc20Interface, CTokenInterface} from "compound-protocol-2.8.1/contracts/CTokenInterfaces.sol";
@@ -18,8 +19,8 @@ import {CErc20Interface, CTokenInterface} from "compound-protocol-2.8.1/contract
 contract LendingManager is ILendingManager, AccessControlEnumerable, ReentrancyGuard, Pausable {
     using SafeERC20 for IERC20;
 
-    bytes32 public constant VAULT_ROLE = keccak256("VAULT_ROLE");
-    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    bytes32 public constant VAULT_ROLE = Roles.VAULT_ROLE;
+    bytes32 public constant ADMIN_ROLE = Roles.ADMIN_ROLE;
 
     uint256 public constant R0_BASIS_POINTS = 5;
     uint256 public constant BASIS_POINTS_DENOMINATOR = 10_000;

--- a/src/Roles.sol
+++ b/src/Roles.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Common role definitions used across the Collection Vault system
+library Roles {
+    bytes32 internal constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    bytes32 internal constant VAULT_ROLE = keccak256("VAULT_ROLE");
+    bytes32 internal constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
+    bytes32 internal constant DEBT_SUBSIDIZER_ROLE = keccak256("DEBT_SUBSIDIZER_ROLE");
+}


### PR DESCRIPTION
## Summary
- centralize all role identifiers in a new `Roles` library
- reference unified role constants across contracts

## Testing
- `forge build`
- `forge test -vvv` *(fails: No tests to run)*

------
https://chatgpt.com/codex/tasks/task_e_685084a5de44832085ddce439f23a915